### PR TITLE
Fix go-micro import paths and update Go version to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: true
 
       - name: Install golangci-lint
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: true
 
       - name: Install Protocol Buffers compiler
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: true
 
       - name: Download proto artifacts
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: true
 
       - name: Download proto artifacts

--- a/cmd/marketdata/main.go
+++ b/cmd/marketdata/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/abdoElHodaky/tradSys/internal/marketdata"
 	"github.com/abdoElHodaky/tradSys/internal/micro"
 	"github.com/abdoElHodaky/tradSys/proto/marketdata"
-	"go-micro.dev/v4"
+	"github.com/micro/go-micro/v4"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
@@ -41,4 +41,3 @@ func registerMarketDataHandler(
 
 	logger.Info("Market data service registered")
 }
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abdoElHodaky/tradSys
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.11
@@ -117,3 +117,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 )
+
+replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
+
+replace google.golang.org/genproto/googleapis/rpc => google.golang.org/genproto/googleapis/rpc v0.0.0-20230410155749-daa745c078e1

--- a/internal/architecture/discovery/discovery.go
+++ b/internal/architecture/discovery/discovery.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"go-micro.dev/v4/registry"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/zap"
 )
 

--- a/internal/architecture/fx/discovery.go
+++ b/internal/architecture/fx/discovery.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/abdoElHodaky/tradSys/internal/architecture/discovery"
-	"go-micro.dev/v4/registry"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/internal/architecture/gateway/gateway.go
+++ b/internal/architecture/gateway/gateway.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/abdoElHodaky/tradSys/internal/architecture/discovery"
 	"github.com/gin-gonic/gin"
-	"go-micro.dev/v4/registry"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/zap"
 )
 

--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/abdoElHodaky/tradSys/internal/config"
-	"go-micro.dev/v4/broker"
+	"github.com/micro/go-micro/v4/broker"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
@@ -63,4 +63,3 @@ func NewBroker(p BrokerParams) broker.Broker {
 var BrokerModule = fx.Options(
 	fx.Provide(NewBroker),
 )
-

--- a/internal/micro/registry.go
+++ b/internal/micro/registry.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/abdoElHodaky/tradSys/internal/config"
-	"go-micro.dev/v4/registry"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/internal/micro/service.go
+++ b/internal/micro/service.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/abdoElHodaky/tradSys/internal/config"
-	gomicro "go-micro.dev/v4"
-	"go-micro.dev/v4/registry"
+	gomicro "github.com/micro/go-micro/v4"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/internal/tests/integration_test.go
+++ b/internal/tests/integration_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/abdoElHodaky/tradSys/internal/config"
 	"github.com/abdoElHodaky/tradSys/internal/micro"
-	gomicro "go-micro.dev/v4"
-	"go-micro.dev/v4/registry"
+	gomicro "github.com/micro/go-micro/v4"
+	"github.com/micro/go-micro/v4/registry"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"


### PR DESCRIPTION
- Changed all go-micro.dev/v4 imports to github.com/micro/go-micro/v4
- Updated Go version from 1.19 to 1.20 in CI workflow
- Added replace directives for google.golang.org/genproto to fix dependency conflicts