### PR TITLE
Refactor micro dependencies to use go-micro.dev/v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,3 @@ require (
 
 // Fix for go-micro.dev/v4 dependencies
 replace github.com/micro/go-micro/v4 => go-micro.dev/v4 v4.10.2
-
-//replace go-micro.dev/v4/client/selector => go-micro.dev/v4 v4.10.2
-

--- a/internal/micro/mesh.go
+++ b/internal/micro/mesh.go
@@ -3,14 +3,10 @@ package micro
 import (
 	"github.com/abdoElHodaky/tradSys/internal/config"
 
-
-
-	gomicro "github.com/micro/go-micro/v4"
-	"github.com/micro/go-micro/v4/client"
-	"github.com/micro/go-micro/v4/client/selector"
-	"github.com/micro/go-micro/v4/server"
-
-
+	gomicro "go-micro.dev/v4"
+	"go-micro.dev/v4/client"
+	"go-micro.dev/v4/registry"
+	"go-micro.dev/v4/server"
 
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
- Updated imports in mesh.go to use go-micro.dev/v4 instead of github.com/micro/go-micro/v4
- Removed selector import as it's not available in go-micro.dev/v4/client
- Added registry import for proper service discovery
- Cleaned up go.mod replace directives
- Ensured compatibility with Go 1.20