### PR TITLE
Fix atomic operations in adaptive_loader and update go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/abdoElHodaky/tradSys
 
-go 1.23.2
-
-toolchain go1.24.6
+go 1.23
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/internal/plugin/adaptive_loader/adaptive_loader.go
+++ b/internal/plugin/adaptive_loader/adaptive_loader.go
@@ -174,7 +174,7 @@ func (l *AdaptivePluginLoader) StartPluginScanner(ctx context.Context, scanInter
 	}
 	
 	// Start the worker pool if not already running
-	if l.workerPool != nil && atomic.LoadInt32(&l.workerPool.running) == 0 {
+	if l.workerPool != nil && atomic.LoadInt64(&l.workerPool.running) == 0 {
 		l.workerPool.Start()
 		l.logger.Info("Started worker pool for plugin operations")
 	}
@@ -268,7 +268,7 @@ func (l *AdaptivePluginLoader) StopPluginScanner() {
 	}
 	
 	// Stop the worker pool if it's running
-	if l.workerPool != nil && atomic.LoadInt32(&l.workerPool.running) == 1 {
+	if l.workerPool != nil && atomic.LoadInt64(&l.workerPool.running) == 1 {
 		l.workerPool.Stop()
 		l.logger.Info("Stopped worker pool for plugin operations")
 	}


### PR DESCRIPTION
- Changed atomic.LoadInt32 to atomic.LoadInt64 for worker pool running state checks
- Fixed go.mod version to 1.23 (from 1.23.2) and removed toolchain directive